### PR TITLE
Update watch.js to work with windows git bash

### DIFF
--- a/build/scripts/watch.js
+++ b/build/scripts/watch.js
@@ -104,8 +104,8 @@ function alertBuildResult(buildResult) {
 
 function flushCaches() {
 	Object.keys(require.cache).forEach((key) => {
-		const srcDirPrefix = pathLib.resolve("./src") + "/";
-		const nodeModulesPrefix = pathLib.resolve("./node_modules") + "/";
+		const srcDirPrefix = pathLib.resolve("./src");
+		const nodeModulesPrefix = pathLib.resolve("./node_modules");
 
 		if (key.startsWith(srcDirPrefix) || key.startsWith(nodeModulesPrefix)) delete require.cache[key];
 	});


### PR DESCRIPTION
In git bash with `const srcDirPrefix = pathLib.resolve("./src")`  it was resolving to `'C:\\projects\\livestream\\src'` when adding the trailing '/' the key it was trying to delete would be `C:\projects\\livestream\\src/` which didn't exist in the cache, but if you remove the trailing slash it does exist.  

The result being that the file `C:\\projects\\livestream\\src\__my_test.js` was still in the cache and wouldn't get tested by the mocha test runner.

Looking at the code it appears that the trailing slash shouldn't matter unless you have another folder/file who's cache you don't want deleted that starts with `src` or `node_modules` so this shouldn't be run into in practice.

